### PR TITLE
feature: added update manifest script and github action

### DIFF
--- a/.github/workflows/info-json.yml
+++ b/.github/workflows/info-json.yml
@@ -1,0 +1,139 @@
+# Regenerates the manifests (info.json / info.files.json) whenever the tiles change
+# and publishes them on the TARGET_BRANCH, without touching any tile file.
+#
+# To configure it, edit the env: block below. If you change SOURCE_BRANCH you must
+# also change the branch name under on: push: - GitHub does not allow a variable there.
+
+name: Update info.json
+
+on:
+  push:
+    branches: [master]  # must be literal - keep in sync with SOURCE_BRANCH
+  workflow_dispatch:    # adds a "Run workflow" button on the Actions tab
+
+env:
+  SOURCE_BRANCH: master     # branch the tiles live on
+  TARGET_BRANCH: with-json  # branch the manifests are published to
+  INFO_FILE: info.json          # folder level manifest, few KB
+  DETAIL_FILE: info.files.json  # per file manifest, few MB
+
+permissions:
+  contents: write
+
+concurrency: # only one run at a time, so two runs cannot race each other while pushing
+  group: info-json        
+  cancel-in-progress: false
+
+jobs:
+  info-json:
+    runs-on: ubuntu-latest
+    steps:
+      # Downloads the tiles. fetch-depth 1 grabs only the newest commit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_BRANCH }}
+          fetch-depth: 1
+
+      # RUNNER_TEMP is a scratch folder outside the repo, so writing the new
+      # manifests there does not show up as a change to the checkout.
+      - name: Generate manifests
+        run: |
+          python3 .scripts/create_info_json.py --root . --out-dir "$RUNNER_TEMP/new" \
+            --info-name "$INFO_FILE" --detail-name "$DETAIL_FILE"
+
+      # Grabs the manifests that are already published, to compare against.
+      - name: Read published manifests
+        id: published
+        run: |
+          set -eu  # stop on the first error, and on any unset variable
+
+          mkdir -p "$RUNNER_TEMP/old"
+
+          # Work out where the published manifests currently live.
+          if [ "$TARGET_BRANCH" = "$SOURCE_BRANCH" ]; then
+            # Publishing onto the same branch, so they are in this checkout already.
+            ref=HEAD
+          elif git fetch --depth=1 origin "+refs/heads/$TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH"; then
+            # The target branch exists. Remember its commit id - the push step
+            # needs it. Writing to GITHUB_OUTPUT passes a value to a later step.
+            ref="origin/$TARGET_BRANCH"
+            echo "target_sha=$(git rev-parse "$ref")" >> "$GITHUB_OUTPUT"
+          else
+            # The fetch failed, so the branch does not exist yet. Means this is first run.
+            echo "$TARGET_BRANCH does not exist yet"
+            ref=""
+          fi
+
+          # Copy each published manifest out of that branch. "git show branch:file"
+          # prints one file from a branch without checking the branch out.
+          for f in "$INFO_FILE" "$DETAIL_FILE"; do
+            rm -f "$RUNNER_TEMP/old/$f"
+            if [ -n "$ref" ]; then
+              # A failure here just means the branch has no manifest yet, which
+              # counts as "different" in the next step.
+              git show "$ref:$f" > "$RUNNER_TEMP/old/$f" 2>/dev/null || rm -f "$RUNNER_TEMP/old/$f"
+            fi
+          done
+
+      # Decides whether anything is worth publishing. The compare script ignores
+      # the generated_at timestamp, otherwise every run would look different and
+      # the workflow would commit forever.
+      - name: Compare
+        id: compare
+        run: |
+          set -eu
+          changed=false
+          for f in "$INFO_FILE" "$DETAIL_FILE"; do
+            # The script exits 0 when the two files match, 1 when they differ.
+            python3 .scripts/compare_info_json.py "$RUNNER_TEMP/old/$f" "$RUNNER_TEMP/new/$f" || changed=true
+          done
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      # Builds the commit by hand instead of "git add" + "git commit", so all
+      # of the tile files are never copied or rewritten. The commit reuses the
+      # source branch's tree as is and only adds the two manifests on top.
+      # Note: publishing onto master itself requires master to be unprotected.
+      - name: Commit and push
+        if: steps.compare.outputs.changed == 'true'  # skip the whole step when nothing changed
+        env:
+          TARGET_SHA: ${{ steps.published.outputs.target_sha }}  # empty if the branch is new
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -eu
+
+          # Build the file list for the new commit in a scratch index file, so the
+          # checkout's own index is left alone.
+          export GIT_INDEX_FILE="$RUNNER_TEMP/index"
+          rm -f "$GIT_INDEX_FILE"
+
+          # Start from exactly what the source branch contains.
+          git read-tree HEAD
+
+          # Store each manifest in the repository and put it in the file list.
+          # 100644 is git's code for a normal, non executable file.
+          for f in "$INFO_FILE" "$DETAIL_FILE"; do
+            blob=$(git hash-object -w "$RUNNER_TEMP/new/$f")
+            git update-index --add --cacheinfo "100644,$blob,$f"
+          done
+
+          # Freeze that file list into a tree, the snapshot a commit points at.
+          tree=$(git write-tree)
+          source_sha=$(git rev-parse HEAD)
+
+          # Pick the new commit's parents. Listing the target branch's current
+          # commit first makes the new commit a direct descendant of it, so the
+          # push is an ordinary fast forward and never needs --force.
+          if [ "$TARGET_BRANCH" != "$SOURCE_BRANCH" ] && [ -n "${TARGET_SHA:-}" ]; then
+            parents=(-p "$TARGET_SHA" -p "$source_sha")
+          else
+            # First run on a new branch, or publishing onto the source branch.
+            parents=(-p "$source_sha")
+          fi
+
+          # Create the commit and move the target branch to it. [skip ci] keeps
+          # this push from triggering the workflow again.
+          commit=$(git commit-tree "$tree" "${parents[@]}" -m "chore: update $INFO_FILE [skip ci]")
+          git push origin "$commit:refs/heads/$TARGET_BRANCH"

--- a/.scripts/compare_info_json.py
+++ b/.scripts/compare_info_json.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Compare two manifests ignoring generated_at. Exit 0 if equal, 1 if different.
+
+generated_at changes on every run, so a byte comparison would make the workflow
+commit forever. A missing or unreadable OLD counts as different.
+"""
+import json
+import sys
+
+
+def load(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = json.load(f)
+    except (OSError, ValueError):
+        return None
+    doc.pop("generated_at", None)
+    return doc
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: compare_info_json.py OLD NEW")
+    old, new = load(sys.argv[1]), load(sys.argv[2])
+    if new is None:
+        sys.exit(f"cannot read {sys.argv[2]}")
+    same = old == new
+    print("same" if same else "different")
+    sys.exit(0 if same else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.scripts/create_info_json.py
+++ b/.scripts/create_info_json.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate the info.json / info.files.json manifests for the tile folders.
+
+Root files and anything starting with "." are skipped. Every folder gets a hash
+built from its children's hashes, so a hash change points straight at what moved.
+"""
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+MANIFEST_VERSION = 1
+CHUNK = 1 << 20
+
+
+def file_node(path):
+    h = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as f:
+        while chunk := f.read(CHUNK):
+            h.update(chunk)
+            size += len(chunk)
+    return {"hash": h.hexdigest(), "size": size}
+
+
+def folder_node(path, skip_files=False):
+    """Walk one folder. Children are sorted by name so output is deterministic."""
+    folders, files = {}, {}
+    for entry in sorted(os.scandir(path), key=lambda e: e.name):
+        if entry.name.startswith("."):
+            continue
+        if entry.is_dir():
+            folders[entry.name] = folder_node(entry.path)
+        elif entry.is_file() and not skip_files:
+            files[entry.name] = file_node(entry.path)
+
+    children = [("d", n, v) for n, v in folders.items()]
+    children += [("f", n, v) for n, v in files.items()]
+    h = hashlib.sha256()
+    for kind, name, node in sorted(children, key=lambda c: c[1]):
+        h.update(f"{kind} {node['hash']} {name}\n".encode("utf-8"))
+
+    return {
+        "hash": h.hexdigest(),
+        "size": sum(n["size"] for n in (*folders.values(), *files.values())),
+        "item_count": sum(n["item_count"] for n in folders.values()) + len(files),
+        "folders": folders,
+        "files": files,
+    }
+
+
+def without_files(folders):
+    return {
+        name: {
+            "hash": n["hash"],
+            "size": n["size"],
+            "item_count": n["item_count"],
+            "folders": without_files(n["folders"]),
+        }
+        for name, n in folders.items()
+    }
+
+
+def document(root, generated_at, detailed, detail_name):
+    doc = {
+        "manifest_version": MANIFEST_VERSION,
+        "generated_at": generated_at,
+        "hash_algorithm": "sha256",
+        "detailed": detailed,
+    }
+    if not detailed:
+        doc["detail_file"] = detail_name
+    doc["hash"] = root["hash"]
+    doc["size"] = root["size"]
+    doc["item_count"] = root["item_count"]
+    doc["folders"] = root["folders"] if detailed else without_files(root["folders"])
+    return doc
+
+
+def write_json(path, doc, indent):
+    separators = (",", ": ") if indent else (",", ":")
+    text = json.dumps(doc, indent=indent, separators=separators, ensure_ascii=False)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text + "\n")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", default=".", help="repository root to scan")
+    p.add_argument("--out-dir", default=".", help="where to write the manifests")
+    p.add_argument("--info-name", default="info.json", help="folder-level manifest name")
+    p.add_argument("--detail-name", default="info.files.json", help="per-file manifest name")
+    args = p.parse_args()
+
+    root = folder_node(args.root, skip_files=True)
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    write_json(
+        os.path.join(args.out_dir, args.info_name),
+        document(root, generated_at, False, args.detail_name),
+        indent=2,
+    )
+    write_json(
+        os.path.join(args.out_dir, args.detail_name),
+        document(root, generated_at, True, args.detail_name),
+        indent=None,
+    )
+    print(f"{root['item_count']} files, {root['size']} bytes, hash {root['hash']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -16,3 +16,22 @@ Demo source: https://glitch.com/edit/#!/foxhole-tilemap-prototype
 Now also contains icons that are used in Foxhole maps, created by Clapfoot Inc. and colored by https://github.com/BladeRikWr
 
 Map and icon images are a property of Clapfoot Inc. and are used with their permission.
+
+## Update manifest
+
+The `with-json` branch carries two generated manifests so apps can update only the tiles that actually changed. They are regenerated automatically whenever `master` is updated.
+
+ - `info.json` (~7 KB) — hash, size and file count per folder.
+ - `info.files.json` (~4.4 MB) — the same tree plus every individual file's hash and size.
+
+```
+https://raw.githubusercontent.com/Kastow/Foxhole-Map-Tiles/with-json/info.json
+https://raw.githubusercontent.com/Kastow/Foxhole-Map-Tiles/with-json/info.files.json
+```
+
+Using these useful for apps that caches map tiles between sessions or downloads them for offline usage.
+
+Suggested client flow: fetch `info.json`, compare the root `hash` with the stored one, and only when it differs fetch `info.files.json` and download the files whose hash changed. Folder hashes let you skip whole layers or zoom levels before looking at individual files.
+
+For detailed information check the script itself and github action file. [.scripts/create_info_json.py](.scripts/create_info_json.py), [.github/workflows/info-json.yml](.github/workflows/info-json.yml).
+


### PR DESCRIPTION
(Code is written by AI, reviewed and edited by me)

Fixes #9 . Check "Considerations" before merging.

## Why This PR Made

This PR specifically usefull for projects that uses github as CDN source for map tiles. Such as my project will.

In the app i am developing i cache map tiles between sessions. In web using IndexedDB, on desktop/mobile via file system. This way i decrease network usage of the user and provide a smoother experience on map. 

Right now there is no proper way to check if a tile is updated. By having "info.json" folder i can check if a folder is updated. If related folder is updated then i would fetch "info.files.json" to see which exact files are updated. This way i only re-download new files.

I will also prompt users and ask if they prefer "download and cache files progressively" or "download all map tiles for offline usage (x MB)". By having size information of folders in info.json, i can show how much network and storage will be used for users selections.

## This PR

This PR does two things:

- Adds script that generates 2 json file. One of them (info.json) only has hash and size of folders. Other one (info.files.json) includes all file hash and json as well.
- Adds github action file which on push to 'master', it runs script and if there is changes it pushes to 'with-json' branch. Last state of 'master' is included in 'with-json' branch together with info.json.

info.json is 7~ KB while info.files.json is 4.4~ MB. It is made so users can first check hashes of folders and if nothing important for them is updated they can skip checking info.files.json.

## Considerations

Right now I think info.files.json size is too big. We might want to seperate it into different files deppending on folder name such as: "info.tiles.json", "info.sat.tiles.json" etc. Then just becuase one file changed 4.4~ MB request would not happen. Might be overengineering and could need more complicated implemantation on client side. Need your opinion about this.


## Tests

I have tested this on my fork on following branch: https://github.com/Sravdar/Foxhole-Map-Tiles/tree/add-info-json-test-source

When push happened on that branch github actions triggered succesfully and pushed into https://github.com/Sravdar/Foxhole-Map-Tiles/tree/add-info-json-test-target

As far as i can say this works without problems.

## Tag

@Yin117 